### PR TITLE
[ENG 1510] Fix `needs_cycling?` logic 

### DIFF
--- a/app/models/billing/usage/tracker.rb
+++ b/app/models/billing/usage/tracker.rb
@@ -35,6 +35,6 @@ class Billing::Usage::Tracker < BulletTrain::Billing::Usage.base_class.constanti
   end
 
   def needs_cycling?
-    created_at + duration.send(interval) < Time.zone.now
+    (cycled_at.presence || created_at) + duration.send(interval) < Time.zone.now
   end
 end


### PR DESCRIPTION
This PR adds logic to ensure once a tracker has been cycled it will not be stuck evaluating `needs_cycling?` as `true`

<img width="607" alt="Screenshot 2025-03-20 at 11 17 57 AM" src="https://github.com/user-attachments/assets/01d51f58-4082-4eab-a3bd-cb6289ee0d4f" />